### PR TITLE
Update cvs2git-migrator.sh

### DIFF
--- a/cvs2git-migrator.sh
+++ b/cvs2git-migrator.sh
@@ -336,7 +336,7 @@ if [[ -e "$PROJECT_DIR/git-blob.dat" && -e "$PROJECT_DIR/git-dump.dat" ]]; then
 	    && cd $PROJECT_NAME.git \
 	    && cat ../git-blob.dat ../git-dump.dat | \
 		git fast-import \
-	    && git-move-refs.py \
+	    && ../../external/git-move-refs.py \
 	    && git gc --prune=now \
 	    && echo "Created Bare Git Repository from CVS2GIT Dump in $PROJECT_DIR/$PROJECT_NAME.git"
 


### PR DESCRIPTION
Fix access to the script git-move-refs.py

On my system, this script is not in my PATH, hence the need for a relative path.